### PR TITLE
Adding deprecation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Amazon Device Messaging Java Connector [![Build Status](https://travis-ci.org/aerogear/java-adm.png)](https://travis-ci.org/aerogear/java-adm)
 
+**DEPRECATED**
+
+There are no plans to support this lib any further;
+
+
 A Java Library to send Push Notification to the Amazon Device Messaging Network.
 A complete documentation of the protocol can be found [here](https://developer.amazon.com/appsandservices/apis/engage/device-messaging/)
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
+## Deprecation Notice
+This repository has been deprecated and is not being maintained. If you have any questions, please get in touch with the collaborators.
+
 # Amazon Device Messaging Java Connector [![Build Status](https://travis-ci.org/aerogear/java-adm.png)](https://travis-ci.org/aerogear/java-adm)
-
-**DEPRECATED**
-
-There are no plans to support this lib any further;
-
 
 A Java Library to send Push Notification to the Amazon Device Messaging Network.
 A complete documentation of the protocol can be found [here](https://developer.amazon.com/appsandservices/apis/engage/device-messaging/)


### PR DESCRIPTION
@sebastienblanc I know you wrote it, but I dont think it does make sense to continue this.

For the new UPS, based on Swarm modules, [see](https://github.com/matzew/aerogear-unifiedpush-server/tree/Updates_dev/swarms), I am only adding those libs, that make sense  